### PR TITLE
Add SPDX license identifier and update copyright year

### DIFF
--- a/opl3.c
+++ b/opl3.c
@@ -1,5 +1,7 @@
-/* Nuked OPL3
- * Copyright (C) 2013-2020 Nuke.YKT
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * Copyright (C) 2013-2021  Nuke.YKT
  *
  * This file is part of Nuked OPL3.
  *

--- a/opl3.h
+++ b/opl3.h
@@ -1,5 +1,7 @@
-/* Nuked OPL3
- * Copyright (C) 2013-2020 Nuke.YKT
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * Copyright (C) 2013-2021  Nuke.YKT
  *
  * This file is part of Nuked OPL3.
  *


### PR DESCRIPTION
SPDX (Software Package Data Exchange) identifier is machine-readable
field used propagating license information - it's very useful for cases
where the project consists of many files using slightly different
licenses.

It also makes it easier for users to notice what license is being used,
in specific body of work.

Read more: https://spdx.org/licenses/

Also, separated copyright holder name from the copyright year using two
spaces (as examples in GPL text suggest to do) - this makes it easier to
update copyright years via regular expressions.