### PR TITLE
Adding 4-channel output support and fixing 4-op mode edge case bug

### DIFF
--- a/opl3.c
+++ b/opl3.c
@@ -946,10 +946,8 @@ static void OPL3_ChannelSetupAlg(opl3_channel *channel)
     }
 }
 
-static void OPL3_ChannelWriteC0(opl3_channel *channel, uint8_t data)
+static void OPL3_ChannelUpdateAlg(opl3_channel *channel)
 {
-    channel->fb = (data & 0x0e) >> 1;
-    channel->con = data & 0x01;
     channel->alg = channel->con;
     if (channel->chip->newm)
     {
@@ -974,6 +972,13 @@ static void OPL3_ChannelWriteC0(opl3_channel *channel, uint8_t data)
     {
         OPL3_ChannelSetupAlg(channel);
     }
+}
+
+static void OPL3_ChannelWriteC0(opl3_channel *channel, uint8_t data)
+{
+    channel->fb = (data & 0x0e) >> 1;
+    channel->con = data & 0x01;
+    OPL3_ChannelUpdateAlg(channel);
     if (channel->chip->newm)
     {
         channel->cha = ((data >> 4) & 0x01) ? ~0 : 0;
@@ -1070,11 +1075,14 @@ static void OPL3_ChannelSet4Op(opl3_chip *chip, uint8_t data)
         {
             chip->channel[chnum].chtype = ch_4op;
             chip->channel[chnum + 3].chtype = ch_4op2;
+            OPL3_ChannelUpdateAlg(&chip->channel[chnum]);
         }
         else
         {
             chip->channel[chnum].chtype = ch_2op;
             chip->channel[chnum + 3].chtype = ch_2op;
+            OPL3_ChannelUpdateAlg(&chip->channel[chnum]);
+            OPL3_ChannelUpdateAlg(&chip->channel[chnum+3]);
         }
     }
 }

--- a/opl3.c
+++ b/opl3.c
@@ -978,10 +978,14 @@ static void OPL3_ChannelWriteC0(opl3_channel *channel, uint8_t data)
     {
         channel->cha = ((data >> 4) & 0x01) ? ~0 : 0;
         channel->chb = ((data >> 5) & 0x01) ? ~0 : 0;
+        channel->chc = ((data >> 6) & 0x01) ? ~0 : 0;
+        channel->chd = ((data >> 7) & 0x01) ? ~0 : 0;
     }
     else
     {
         channel->cha = channel->chb = (uint16_t)~0;
+        // TODO: Verify on real chip if DAC2 output is disabled in compat mode
+        channel->chc = channel->chd = 0;
     }
 #if OPL_ENABLE_STEREOEXT
     if (!channel->chip->stereoext)
@@ -1096,17 +1100,18 @@ static void OPL3_ProcessSlot(opl3_slot *slot)
     OPL3_SlotGenerate(slot);
 }
 
-void OPL3_Generate(opl3_chip *chip, int16_t *buf)
+inline void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
 {
     opl3_channel *channel;
     opl3_writebuf *writebuf;
     int16_t **out;
-    int32_t mix;
+    int32_t mix[2];
     uint8_t ii;
     int16_t accm;
     uint8_t shift = 0;
 
-    buf[1] = OPL3_ClipSample(chip->mixbuff[1]);
+    buf4[1] = OPL3_ClipSample(chip->mixbuff[1]);
+    buf4[3] = OPL3_ClipSample(chip->mixbuff[3]);
 
 #if OPL_QUIRK_CHANNELSAMPLEDELAY
     for (ii = 0; ii < 15; ii++)
@@ -1117,19 +1122,21 @@ void OPL3_Generate(opl3_chip *chip, int16_t *buf)
         OPL3_ProcessSlot(&chip->slot[ii]);
     }
 
-    mix = 0;
+    mix[0] = mix[1] = 0;
     for (ii = 0; ii < 18; ii++)
     {
         channel = &chip->channel[ii];
         out = channel->out;
         accm = *out[0] + *out[1] + *out[2] + *out[3];
 #if OPL_ENABLE_STEREOEXT
-        mix += (int16_t)((accm * channel->leftpan) >> 16);
+        mix[0] += (int16_t)((accm * channel->leftpan) >> 16);
 #else
-        mix += (int16_t)(accm & channel->cha);
-#endif
+        mix[0] += (int16_t)(accm & channel->cha);
+ #endif
+        mix[1] += (int16_t)(accm & channel->chc);
     }
-    chip->mixbuff[0] = mix;
+    chip->mixbuff[0] = mix[0];
+    chip->mixbuff[2] = mix[1];
 
 #if OPL_QUIRK_CHANNELSAMPLEDELAY
     for (ii = 15; ii < 18; ii++)
@@ -1138,7 +1145,8 @@ void OPL3_Generate(opl3_chip *chip, int16_t *buf)
     }
 #endif
 
-    buf[0] = OPL3_ClipSample(chip->mixbuff[0]);
+    buf4[0] = OPL3_ClipSample(chip->mixbuff[0]);
+    buf4[2] = OPL3_ClipSample(chip->mixbuff[2]);
 
 #if OPL_QUIRK_CHANNELSAMPLEDELAY
     for (ii = 18; ii < 33; ii++)
@@ -1147,19 +1155,21 @@ void OPL3_Generate(opl3_chip *chip, int16_t *buf)
     }
 #endif
 
-    mix = 0;
+    mix[0] = mix[1] = 0;
     for (ii = 0; ii < 18; ii++)
     {
         channel = &chip->channel[ii];
         out = channel->out;
         accm = *out[0] + *out[1] + *out[2] + *out[3];
 #if OPL_ENABLE_STEREOEXT
-        mix += (int16_t)((accm * channel->rightpan) >> 16);
+        mix[0] += (int16_t)((accm * channel->rightpan) >> 16);
 #else
-        mix += (int16_t)(accm & channel->chb);
-#endif
+        mix[0] += (int16_t)(accm & channel->chb);
+ #endif
+        mix[1] += (int16_t)(accm & channel->chd);
     }
-    chip->mixbuff[1] = mix;
+    chip->mixbuff[1] = mix[0];
+    chip->mixbuff[3] = mix[1];
 
 #if OPL_QUIRK_CHANNELSAMPLEDELAY
     for (ii = 33; ii < 36; ii++)
@@ -1234,20 +1244,42 @@ void OPL3_Generate(opl3_chip *chip, int16_t *buf)
     chip->writebuf_samplecnt++;
 }
 
-void OPL3_GenerateResampled(opl3_chip *chip, int16_t *buf)
+void OPL3_Generate(opl3_chip *chip, int16_t *buf)
+{
+    int16_t samples[4];
+    OPL3_Generate4Ch(chip, samples);
+    buf[0] = samples[0];
+    buf[1] = samples[1];
+}
+
+void OPL3_Generate4ChResampled(opl3_chip *chip, int16_t *buf4)
 {
     while (chip->samplecnt >= chip->rateratio)
     {
         chip->oldsamples[0] = chip->samples[0];
         chip->oldsamples[1] = chip->samples[1];
-        OPL3_Generate(chip, chip->samples);
+        chip->oldsamples[2] = chip->samples[2];
+        chip->oldsamples[3] = chip->samples[3];
+        OPL3_Generate4Ch(chip, chip->samples);
         chip->samplecnt -= chip->rateratio;
     }
-    buf[0] = (int16_t)((chip->oldsamples[0] * (chip->rateratio - chip->samplecnt)
-                     + chip->samples[0] * chip->samplecnt) / chip->rateratio);
-    buf[1] = (int16_t)((chip->oldsamples[1] * (chip->rateratio - chip->samplecnt)
-                     + chip->samples[1] * chip->samplecnt) / chip->rateratio);
+    buf4[0] = (int16_t)((chip->oldsamples[0] * (chip->rateratio - chip->samplecnt)
+                        + chip->samples[0] * chip->samplecnt) / chip->rateratio);
+    buf4[1] = (int16_t)((chip->oldsamples[1] * (chip->rateratio - chip->samplecnt)
+                        + chip->samples[1] * chip->samplecnt) / chip->rateratio);
+    buf4[2] = (int16_t)((chip->oldsamples[2] * (chip->rateratio - chip->samplecnt)
+                        + chip->samples[2] * chip->samplecnt) / chip->rateratio);
+    buf4[3] = (int16_t)((chip->oldsamples[3] * (chip->rateratio - chip->samplecnt)
+                        + chip->samples[3] * chip->samplecnt) / chip->rateratio);
     chip->samplecnt += 1 << RSM_FRAC;
+}
+
+void OPL3_GenerateResampled(opl3_chip *chip, int16_t *buf)
+{
+    int16_t samples[4];
+    OPL3_Generate4ChResampled(chip, samples);
+    buf[0] = samples[0];
+    buf[1] = samples[1];
 }
 
 void OPL3_Reset(opl3_chip *chip, uint32_t samplerate)
@@ -1461,9 +1493,26 @@ void OPL3_WriteRegBuffered(opl3_chip *chip, uint16_t reg, uint8_t v)
     chip->writebuf_last = (writebuf_last + 1) % OPL_WRITEBUF_SIZE;
 }
 
+void OPL3_Generate4ChStream(opl3_chip *chip, int16_t *sndptr1, int16_t *sndptr2, uint32_t numsamples)
+{
+    uint_fast32_t i;
+    int16_t samples[4];
+
+    for(i = 0; i < numsamples; i++)
+    {
+        OPL3_Generate4ChResampled(chip, samples);
+        sndptr1[0] = samples[0];
+        sndptr1[1] = samples[1];
+        sndptr2[0] = samples[2];
+        sndptr2[1] = samples[3];
+        sndptr1 += 2;
+        sndptr2 += 2;
+    }
+}
+
 void OPL3_GenerateStream(opl3_chip *chip, int16_t *sndptr, uint32_t numsamples)
 {
-    uint32_t i;
+    uint_fast32_t i;
 
     for(i = 0; i < numsamples; i++)
     {

--- a/opl3.h
+++ b/opl3.h
@@ -101,6 +101,7 @@ struct _opl3_channel {
     uint8_t alg;
     uint8_t ksv;
     uint16_t cha, chb;
+    uint16_t chc, chd;
     uint8_t ch_num;
 };
 
@@ -128,7 +129,7 @@ struct _opl3_chip {
     uint8_t tremoloshift;
     uint32_t noise;
     int16_t zeromod;
-    int32_t mixbuff[2];
+    int32_t mixbuff[4];
     uint8_t rm_hh_bit2;
     uint8_t rm_hh_bit3;
     uint8_t rm_hh_bit7;
@@ -143,8 +144,8 @@ struct _opl3_chip {
     /* OPL3L */
     int32_t rateratio;
     int32_t samplecnt;
-    int16_t oldsamples[2];
-    int16_t samples[2];
+    int16_t oldsamples[4];
+    int16_t samples[4];
 
     uint64_t writebuf_samplecnt;
     uint32_t writebuf_cur;
@@ -159,6 +160,10 @@ void OPL3_Reset(opl3_chip *chip, uint32_t samplerate);
 void OPL3_WriteReg(opl3_chip *chip, uint16_t reg, uint8_t v);
 void OPL3_WriteRegBuffered(opl3_chip *chip, uint16_t reg, uint8_t v);
 void OPL3_GenerateStream(opl3_chip *chip, int16_t *sndptr, uint32_t numsamples);
+
+void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4);
+void OPL3_Generate4ChResampled(opl3_chip *chip, int16_t *buf4);
+void OPL3_Generate4ChStream(opl3_chip *chip, int16_t *sndptr1, int16_t *sndptr2, uint32_t numsamples);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description

- OPL3_Generate has been refactored into OPL3_Generate4Ch.
  - OPL3_Generate4Ch contains the original logic for sample generation, but modified to output into 4 channels (2 DACs) like the real chip does
  - Added shims for OPL3_Generate, OPL3_GenerateResampled and OPL3_GenerateStream to maintain compatibility with existing applications that expect 2 channel output
  - Tested on a hacked version of Furnace Tracker, 4 channel output works as expected, 2 channel output still works the same.
- Fixed bug where setting the 4-op flags would not immediately change the channel connections until a write to base 0xC0 was issued (bug encountered in Adlib Tracker II when previewing instruments, [confirmed by ValleyBell to not occur in real hardware](https://discord.com/channels/218044739893592064/265645687520100372/840982861342572544))

## Notes

- Added inline attribute to OPL3_Generate4Ch; checked on Compiler Explorer and with -O3 optimizations on GCC this results in OPL3_Generate (and GenerateResampled) being generated with very similar code to the original which should result in almost no performance impact for apps that only use 2 channel output.
  - If -O2 is used, GCC chooses to not inline the code (as if the inline hint wasn't there). Did not check other compilers.