### PR TITLE
Add OPL3_WriteRegDelayed() to buffer with a custom delay

### DIFF
--- a/opl3.h
+++ b/opl3.h
@@ -159,6 +159,7 @@ void OPL3_GenerateResampled(opl3_chip *chip, int16_t *buf);
 void OPL3_Reset(opl3_chip *chip, uint32_t samplerate);
 void OPL3_WriteReg(opl3_chip *chip, uint16_t reg, uint8_t v);
 void OPL3_WriteRegBuffered(opl3_chip *chip, uint16_t reg, uint8_t v);
+void OPL3_WriteRegDelayed(opl3_chip *chip, uint16_t reg, uint8_t v, uint64_t delay);
 void OPL3_GenerateStream(opl3_chip *chip, int16_t *sndptr, uint32_t numsamples);
 
 void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4);


### PR DESCRIPTION
Currently, OPL3_WriteRegBuffered() will delay any write by 2 (non-resampled) samples. It's possible that we might want to delay writes by some other (possibly variable) amount.

OPL3_WriteRegDelayed() accepts an additional 'delay' argument, which contains the number of 49,716Hz samples to delay the write by.