### PR TITLE
Some MSVC versions can generate this error: C2054: expected '(' to follow 'inline'

### DIFF
--- a/opl3.c
+++ b/opl3.c
@@ -33,6 +33,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+#define inline		__inline
+#endif
+
 #include "opl3.h"
 
 #if OPL_ENABLE_STEREOEXT && !defined OPL_SIN


### PR DESCRIPTION
While fixing adplug (it has a clone of nuked-OPL3) MSVC CI, I stumbled across this problem