### PR TITLE
Use 13 bits for chip->eg_timer

### DIFF
--- a/opl3.c
+++ b/opl3.c
@@ -1209,7 +1209,7 @@ inline void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
     chip->eg_add = 0;
     if (chip->eg_timer)
     {
-        while (shift < 36 && ((chip->eg_timer >> shift) & 1) == 0)
+        while (shift < 13 && ((chip->eg_timer >> shift) & 1) == 0)
         {
             shift++;
         }
@@ -1225,7 +1225,7 @@ inline void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
 
     if (chip->eg_timerrem || chip->eg_state)
     {
-        if (chip->eg_timer == UINT64_C(0xfffffffff))
+        if (chip->eg_timer == 0x1fff)
         {
             chip->eg_timer = 0;
             chip->eg_timerrem = 1;

--- a/opl3.h
+++ b/opl3.h
@@ -115,7 +115,7 @@ struct _opl3_chip {
     opl3_channel channel[18];
     opl3_slot slot[36];
     uint16_t timer;
-    uint64_t eg_timer;
+    uint16_t eg_timer;
     uint8_t eg_timerrem;
     uint8_t eg_state;
     uint8_t eg_add;


### PR DESCRIPTION
Reduce width of `chip->eg_timer` to `uint16_t` and only use 13 bits. Any `shift` greater than 12 results in `chip->eg_add = 0`, so previous width was wider than necessary and we were performing useless iterations through loop.